### PR TITLE
Created accent processing (Tilde, Caret, Accute and Grave)

### DIFF
--- a/js/angular-on-screen-keyboard.js
+++ b/js/angular-on-screen-keyboard.js
@@ -1,30 +1,30 @@
 /* global angular:false */
 angular.module('onScreenKeyboard', ['ngSanitize'])
     .directive('onScreenKeyboard', function ($timeout, $document) {
-      'use strict';
-      
+        'use strict';
+
         return {
             restrict: 'E',
             bindToController: true,
             controllerAs: 'ctrl',
             scope: {
-                rows : '=?',
-                uppercaseAllWords : '@',
+                rows: '=?',
+                uppercaseAllWords: '@',
             },
-            controller: function($sce){
+            controller: function ($sce) {
                 var ctrl = this;
 
-                if (!ctrl.rows){
+                if (!ctrl.rows) {
                     ctrl.rows = [
-                        ['1', '2', '3', '4','5','6','7','8', '9', '0', {type: 'erase', colspan: 2, text: '&lArr;'}],
-                        ['q','w','e','r','t','y','u','i','o','p','@'],
-                        ['a','s','d','f','g','h','j','k','l','-','_', {type: 'margin'}],
-                        [{type: 'shift', upperCase: '&dArr;', lowerCase: '&uArr;'}, 'z','x','c','v','b','n','m',',', '.',{type: 'shift', upperCase: '&dArr;', lowerCase: '&uArr;'}],
-                        [{type: 'margin'}, {type: 'space', colspan: 9, text: ' '}]
+                        ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0', { type: 'erase', colspan: 2, text: '&lArr;' }],
+                        ['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', '@'],
+                        ['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', '-', '_', { type: 'margin' }],
+                        [{ type: 'shift', upperCase: '&dArr;', lowerCase: '&uArr;' }, 'z', 'x', 'c', 'v', 'b', 'n', 'm', ',', '.', { type: 'shift', upperCase: '&dArr;', lowerCase: '&uArr;' }],
+                        [{ type: 'margin' }, { type: 'space', colspan: 9, text: ' ' }]
                     ];
                 }
 
-                ctrl.getText = function(key){
+                ctrl.getText = function (key) {
                     if (key.type === 'margin')
                         return '';
 
@@ -32,9 +32,9 @@ angular.module('onScreenKeyboard', ['ngSanitize'])
 
                     if (key.text)
                         val = key.text;
-                    else  if (key.lowerCase && !ctrl.isUpperCase)
+                    else if (key.lowerCase && !ctrl.isUpperCase)
                         val = key.lowerCase;
-                    else  if (key.upperCase && ctrl.isUpperCase)
+                    else if (key.upperCase && ctrl.isUpperCase)
                         val = key.upperCase;
                     else {
                         val = ctrl.isUpperCase ? key.toUpperCase() : key.toLowerCase();
@@ -52,20 +52,32 @@ angular.module('onScreenKeyboard', ['ngSanitize'])
                 ctrl.lastInputCtrl = null;
                 ctrl.startPos = null;
                 ctrl.endPos = null;
+                ctrl.accent = null;
 
-                ctrl.printKeyStroke = function(key, event){
+                ctrl.printKeyStroke = function (key, event) {
                     if (!ctrl.lastInputCtrl)
                         return;
 
                     ctrl.startPos = ctrl.lastInputCtrl.selectionStart;
                     ctrl.endPos = ctrl.lastInputCtrl.selectionEnd;
-
-                    if (key.type === 'erase'){
-                        ctrl.eraseKeyStroke();
-                        return;
-                    } else if (key.type === 'shift'){
-                        ctrl.isUpperCase = !ctrl.isUpperCase;
-                        return;
+                    
+                    switch (key.type){
+                        case 'erase':
+                            ctrl.eraseKeyStroke();
+                            return;
+                            break;
+                        case 'shift':
+                            ctrl.isUpperCase = !ctrl.isUpperCase;
+                            return;
+                            break;
+                        case 'accent':
+                            ctrl.accent = key.text;
+                            ctrl.lastInputCtrl.selectionStart = ctrl.startPos;
+                            ctrl.lastInputCtrl.selectionEnd = ctrl.startPos;
+                            ctrl.setKeyboardLayout();
+                            ctrl.refocus();
+                            return;
+                            break;
                     }
 
                     var htmlKeyVal = angular.element(event.target || event.srcElement).text();
@@ -73,11 +85,24 @@ angular.module('onScreenKeyboard', ['ngSanitize'])
                     var val = lastInputCtrl.val();
                     var pre = val.substring(0, ctrl.startPos);
                     var post = val.substring(ctrl.endPos, val.length);
-                    lastInputCtrl.val(pre + htmlKeyVal + post);
-                    lastInputCtrl.triggerHandler('change');
 
-                    ctrl.startPos += htmlKeyVal.length;
-                    ctrl.endPos += htmlKeyVal.length;
+                    if (ctrl.accent) {
+                        var processedAccentValue = processAccent(ctrl.accent, htmlKeyVal);
+                        lastInputCtrl.val(pre + processedAccentValue + post);
+
+                        ctrl.startPos += processedAccentValue.length;
+                        ctrl.endPos += processedAccentValue.length;
+                        
+                        ctrl.accent = null;
+                    }
+                    else {
+                        lastInputCtrl.val(pre + htmlKeyVal + post);
+
+                        ctrl.startPos += htmlKeyVal.length;
+                        ctrl.endPos += htmlKeyVal.length;
+                    }
+
+                    lastInputCtrl.triggerHandler('change');
                     ctrl.lastInputCtrl.selectionStart = ctrl.startPos;
                     ctrl.lastInputCtrl.selectionEnd = ctrl.startPos;
                     ctrl.setKeyboardLayout();
@@ -116,7 +141,7 @@ angular.module('onScreenKeyboard', ['ngSanitize'])
                 };
 
                 ctrl.setKeyboardLayout = function () {
-                    if (!ctrl.lastInputCtrl){
+                    if (!ctrl.lastInputCtrl) {
                         ctrl.isUpperCase = true;
                         return;
                     }
@@ -127,12 +152,12 @@ angular.module('onScreenKeyboard', ['ngSanitize'])
                     }
                     else if (angular.element(ctrl.lastInputCtrl).val().slice(-1) === ' ' && !ctrl.isUpperCase && attr.uppercaseAllWords !== undefined)
                         ctrl.isUpperCase = true;
-                    else{
+                    else {
                         ctrl.isUpperCase = false;
                     }
                 };
 
-                var focusin = function(event){
+                var focusin = function (event) {
                     var e = event.target || event.srcElement;
 
                     if (e.tagName === 'INPUT' || e.tagName === 'TEXTAREA') {
@@ -141,7 +166,7 @@ angular.module('onScreenKeyboard', ['ngSanitize'])
                     }
                 };
 
-                var keyup = function(){
+                var keyup = function () {
                     if (!ctrl.lastInputCtrl)
                         return;
 
@@ -152,10 +177,123 @@ angular.module('onScreenKeyboard', ['ngSanitize'])
                     scope.$digest();
                 };
 
+                var processAccent = function (accent, htmlKeyVal) {
+                    switch (accent) {
+                        case '~':
+                            return processAccentTilde(htmlKeyVal);
+                        case '^':
+                            return processAccentCaret(htmlKeyVal);
+                        case '´':
+                            return processAccentAccute(htmlKeyVal);
+                        case '`':
+                            return processAccentGrave(htmlKeyVal);
+                    }
+                }
+
+                var processAccentTilde = function (htmlKeyVal) {
+                    switch (htmlKeyVal) {
+                        case 'a':
+                            return 'ã';
+                        case 'A':
+                            return 'Ã';
+                        case 'o':
+                            return 'õ';
+                        case 'O':
+                            return 'Õ';
+                        case 'n':
+                            return 'ñ';
+                        case 'N':
+                            return 'Ñ';
+                        default:
+                            return '~' + htmlKeyVal
+                    }
+                }
+
+                var processAccentCaret = function (htmlKeyVal) {
+                    switch (htmlKeyVal) {
+                        case 'a':
+                            return 'â';
+                        case 'A':
+                            return 'Â';
+                        case 'e':
+                            return 'ê';
+                        case 'E':
+                            return 'Ê';
+                        case 'i':
+                            return 'î';
+                        case 'I':
+                            return 'Î';
+                        case 'o':
+                            return 'ô';
+                        case 'O':
+                            return 'Ô';
+                        case 'u':
+                            return 'û';
+                        case 'U':
+                            return 'Û';
+                        default:
+                            return '^' + htmlKeyVal
+                    }
+                }
+
+                var processAccentAccute = function (htmlKeyVal) {
+                    switch (htmlKeyVal) {
+                        case 'a':
+                            return 'á';
+                        case 'A':
+                            return 'Á';
+                        case 'e':
+                            return 'é';
+                        case 'E':
+                            return 'É';
+                        case 'i':
+                            return 'í';
+                        case 'I':
+                            return 'Í';
+                        case 'o':
+                            return 'ó';
+                        case 'O':
+                            return 'Ó';
+                        case 'u':
+                            return 'ú';
+                        case 'U':
+                            return 'Ú';
+                        default:
+                            return '´' + htmlKeyVal
+                    }
+                }
+
+                var processAccentGrave = function (htmlKeyVal) {
+                    switch (htmlKeyVal) {
+                        case 'a':
+                            return 'à';
+                        case 'A':
+                            return 'À';
+                        case 'e':
+                            return 'è';
+                        case 'E':
+                            return 'È';
+                        case 'i':
+                            return 'ì';
+                        case 'I':
+                            return 'Ì';
+                        case 'o':
+                            return 'ò';
+                        case 'O':
+                            return 'Ò';
+                        case 'u':
+                            return 'ù';
+                        case 'U':
+                            return 'Ù';
+                        default:
+                            return '´' + htmlKeyVal
+                    }
+                }
+
                 $document.bind('focusin', focusin);
                 $document.bind('keyup', keyup);
 
-                scope.$on("$destroy", function() {
+                scope.$on("$destroy", function () {
                     $document.unbind('focusin', focusin);
                     $document.unbind('keyup', keyup);
                 });
@@ -165,10 +303,10 @@ angular.module('onScreenKeyboard', ['ngSanitize'])
                     return false;
                 });
 
-                $timeout(function(){
+                $timeout(function () {
                     ctrl.isUpperCase = true;
-                },0);
+                }, 0);
             },
-            templateUrl: '/templates/angular-on-screen-keyboard.html'
+            templateUrl: 'assets/plugins/angular-on-screen-keyboard/angular-on-screen-keyboard.html'
         };
     });


### PR DESCRIPTION
I downloaded this plugin and I liked it very much, but I live in Brazil, and I noticed that the accents when put on "rows" config, just showed on text like any other character. So I upgraded it, and I'd be happy to share it with you. Let me know if you liked it!

The new behavior of accents on this commit is when pressed, wait for the next character. If it supports accent, then the accented letter appear. If it does not supports (eg, "P" doesn't), it shows the accent and next to it the letter (~P).